### PR TITLE
Disable media query for h1 and h2 heading on larger screens

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -32,7 +32,7 @@ h1, h2, h3, h4, h5, h6 {
   --ifm-heading-font-family: "Hanken Grotesk", "Helvetica Neue", "Helvetica", sans-serif;
 }
 
-@media (max-width: 1920px) {
+/* @media (max-width: 1920px) {
   h1 {
     font-size: 24pt;
   }
@@ -40,7 +40,7 @@ h1, h2, h3, h4, h5, h6 {
   h2 {
     font-size: 16pt;
   }
-}
+} */
 
 .field-card {
   border-radius: 0.5rem;


### PR DESCRIPTION
Comment out media query for screen sizes up to 1920px.